### PR TITLE
Improving file metadata upload

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,5 +1,5 @@
 from typing import Optional, List
-from fastapi import APIRouter, HTTPException, Query, File, UploadFile
+from fastapi import APIRouter, HTTPException, Query, File, UploadFile, Form
 from fastapi.responses import RedirectResponse
 import json
 import psycopg2
@@ -571,10 +571,7 @@ def update_metadata(update: MetadataUpdate):
         raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
 @router.post("/ingest/upload_file_metadata")
-async def upload_file_metadata(file: UploadFile = File(...)):
-
-    # will be provided as an input
-    dataset_id_to_use = 1 
+async def upload_file_metadata(dataset_id: int = Form(...), file: UploadFile = File(...)):
 
     try:
         contents = await file.read()
@@ -607,7 +604,7 @@ async def upload_file_metadata(file: UploadFile = File(...)):
                 cursor=cursor,
                 file_list=file_list,
                 file_type_name=file_type,
-                dataset_id=dataset_id_to_use
+                dataset_id=dataset_id
             )
 
             summary[file_type]["count"] = count
@@ -618,7 +615,7 @@ async def upload_file_metadata(file: UploadFile = File(...)):
         
         return {
             "status": "success",
-            "message": f"Succesfully ingested files for dataset ID {dataset_id_to_use}",
+            "message": f"Succesfully ingested files for dataset ID {dataset_id}",
             "summary": {
                 "file_size_unit": file_size_unit,
                 "raw_files": summary["raw"],

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -574,8 +574,8 @@ def update_metadata(update: MetadataUpdate):
     except Error as e:
         raise HTTPException(status_code=500, detail=f"Database error: {e}")
 
-@router.post("/ingest/simple_raw_file_test")
-async def simple_raw_file_test():
+@router.post("/ingest/upload_file_metadata")
+async def upload_file_metadata():
     logging.debug("--- Starting simple raw file test endpoint ---")
 
     # will be provided as an input

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -23,7 +23,6 @@ from app.schemas.schemas import (
     FileMetadataCreate,
     MetadataUpdate,
 )
-import logging
 
 # Replace with your actual connection details
 DB_NAME = "readmedatabase"
@@ -31,9 +30,6 @@ DB_USER = "postgres"
 DB_PASSWORD = "password"
 DB_HOST = "localhost"
 DB_PORT = "5432"
-
-logger = logging.getLogger('uvicorn.error')
-logger.setLevel(logging.DEBUG)
 
 router = APIRouter()
 
@@ -576,7 +572,6 @@ def update_metadata(update: MetadataUpdate):
 
 @router.post("/ingest/upload_file_metadata")
 async def upload_file_metadata(file: UploadFile = File(...)):
-    logging.debug("--- Starting simple raw file test endpoint ---")
 
     # will be provided as an input
     dataset_id_to_use = 1 
@@ -585,7 +580,6 @@ async def upload_file_metadata(file: UploadFile = File(...)):
         contents = await file.read()
         decoded_contents = contents.decode('utf-8')
         ingestion_data = json.loads(decoded_contents)
-        logging.debug("File read and parsed successfully.")
     except (UnicodeDecodeError, json.JSONDecodeError) as e:
         raise HTTPException(status_code=400, detail="Invalid file format. Please upload a valid JSON file.")
 

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -121,3 +121,13 @@ class FileResponse(BaseModel):
     sample_id: Optional[int] = None
     ext_sample_id: Optional[str] = None
     sample_metadata: Optional[List[SampleMetadata]] = None
+
+class FileMetadataItem(BaseModel):
+    metadata_key: str
+    metadata_value: str
+
+class FileWithMetadata(BaseModel):
+    id: int
+    path: str
+    file_type: str
+    metadata: List[FileMetadataItem]

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -128,6 +128,5 @@ class FileMetadataItem(BaseModel):
 
 class FileWithMetadata(BaseModel):
     id: int
-    path: str
     file_type: str
     metadata: List[FileMetadataItem]


### PR DESCRIPTION
Defined a new API that takes in a dataset ID and file as input. 

Checks the file is the right format (if not, will return with error)

Reads through the file to identify metadata for raw / processed / summarised files

Inserts this into the database, into the files and files_metadata tables

Returns with a json summary of number of files uploaded and total size, for raw / processed / summarised